### PR TITLE
Declare character set of UTF-8

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head> 
+    <meta charset="utf-8">
     <script src="dat://2714774d6c464dd12d5f8533e28ffafd79eec23ab20990b5ac14de940680a6fe/rotonde.js"></script>
   </head>
   <body></body>


### PR DESCRIPTION
I think it belongs here @neauoire, because the browser looks for this value at parse time (which makes injection via JavaScript, as utilized for stylesheets in Rotonde/client, unfeasible).

See Rotonde/beaker#69